### PR TITLE
Pass HTTP IP as parameter and Add inventory in .gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,14 @@ $ ansible-playbook compose.yml --ask-sudo-pass
 A short note here: Do not press `Ctrl+c` because that would stop the HTTP server.
 
 
-Now Open a new terminal session and replace `IP_OF_HTTP_SERVER_RUNNING` with the IP Address of HTTP Server running in [rebase.yml](https://github.com/trishnaguha/build-atomic-host/blob/master/rebase.yml#L10) file. You can use `ip addr` to check the IP Address of the HTTP server.
+Now Open a new terminal session and Enter IP Address of HTTP Server running in [rebase.sh](https://github.com/trishnaguha/build-atomic-host/blob/master/rebase.sh#L14) file.
+For Instance:
+```
+ansible-playbook rebase.yml --ask-sudo-pass -i inventory --extra-vars "httpserver=192.168.121.1"
+```
+You can use `ip addr` to check the IP Address of the HTTP server.
 
+Download Fedora Atomic QCOW2 Image: [https://getfedora.org/en/atomic](https://getfedora.org/en/atomic/download/).
 Create VM from the Atomic QCOW2 image
 
 ```

--- a/rebase.sh
+++ b/rebase.sh
@@ -11,4 +11,4 @@ echo -e "[atomichost]\n$vm_ip ansible_ssh_user=atomic-user ansible_ssh_pass=atom
 
 ssh-copy-id -i ~/.ssh/id_rsa.pub atomic-user@$vm_ip
 
-ansible-playbook rebase.yml --ask-sudo-pass -i inventory
+ansible-playbook rebase.yml --ask-sudo-pass -i inventory --extra-vars "httpserver="

--- a/rebase.yml
+++ b/rebase.yml
@@ -7,8 +7,7 @@
   tasks:
   - name: Create remote named my-atomic
     command:
-      ostree remote add my-atomic http://IP_OF_HTTP_SERVER_RUNNING:35000/repo --no-gpg-verify
-      # IP_OF_HTTP_SERVER_RUNNING = 192.168.121.1
+      ostree remote add my-atomic http://'{{ httpserver }}':35000/repo --no-gpg-verify
 
   - name: Rebase on to my tree
     command:


### PR DESCRIPTION
Work on https://github.com/trishnaguha/build-atomic-host/commit/8db8b09cc58babceafc368e78d88d9728b83daf5#commitcomment-20784599
Since `inventory` file is created on the runtime with the IP Address of the atomic-host, we would not want to commit it.